### PR TITLE
Fix Decimal Point Inconsistency in Monetary Display

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ function updateQuantity(taskElement, delta) {
     }
 
     // Update the total for this item
-    totalElement.textContent = `$${itemPrice * newQuantity}`
+    totalElement.textContent = `$${(itemPrice * newQuantity).toFixed(2)}`
 
     updateTotalAmount()
 }


### PR DESCRIPTION
## Changes
- Utilized `.toFixed(2)` method to ensure that all monetary amounts are displayed with two decimal places.
